### PR TITLE
Add Claude Code plugin for automatic conflict detection

### DIFF
--- a/claude-code-plugin/.claude-plugin/marketplace.json
+++ b/claude-code-plugin/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "clash-sh",
+  "version": "1.0.0",
+  "description": "Clash - detect merge conflicts across git worktrees before they happen",
+  "owner": {
+    "name": "Clash Contributors"
+  },
+  "plugins": [
+    {
+      "name": "clash",
+      "description": "Detect merge conflicts across git worktrees before they happen. Warns before writing to files that would cause merge conflicts when running multiple AI agents in parallel.",
+      "version": "0.1.0",
+      "source": ".",
+      "category": "development",
+      "tags": ["git", "worktree", "merge-conflicts", "multi-agent"]
+    }
+  ]
+}

--- a/claude-code-plugin/.claude-plugin/plugin.json
+++ b/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "clash",
+  "description": "Detect merge conflicts across git worktrees before they happen",
+  "version": "0.1.0",
+  "author": {
+    "name": "Clash Contributors"
+  },
+  "homepage": "https://clash.sh",
+  "repository": "https://github.com/clash-sh/clash",
+  "license": "MIT",
+  "keywords": ["git", "worktree", "merge-conflicts", "multi-agent"]
+}

--- a/claude-code-plugin/hooks/hooks.json
+++ b/claude-code-plugin/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Detect merge conflicts across git worktrees before writing files",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "clash check"
+          }
+        ],
+        "matcher": "Write|Edit|MultiEdit"
+      }
+    ]
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ enum Commands {
 }
 
 fn main() {
-    // Force colors to always be enabled regardless of terminal capabilities
+    // Force colors to always be enabled (test)
     // TODO: Make color behavior configurable via --color flag (always/auto/never)
     control::set_override(true);
 
@@ -65,34 +65,14 @@ fn main() {
                 std::process::exit(1);
             }
         },
-        Some(Commands::Check { path }) => {
-            if let Some(ref p) = path {
-                // Manual mode: discover from cwd, exit 2 on conflicts
-                match WorktreeManager::discover() {
-                    Ok(worktrees) => match check::run_check(&worktrees, Some(p)) {
-                        Ok(true) => std::process::exit(2),
-                        Ok(false) => {}
-                        Err(e) => {
-                            eprintln!("Error: {}", e);
-                            std::process::exit(1);
-                        }
-                    },
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        std::process::exit(1);
-                    }
-                }
-            } else {
-                // Hook mode: discover from file path in stdin
-                match check::run_check_from_hook() {
-                    Ok(_) => {}
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        std::process::exit(1);
-                    }
-                }
+        Some(Commands::Check { path }) => match check::run_check(path.as_deref()) {
+            Ok(true) if path.is_some() => std::process::exit(2),
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
             }
-        }
+        },
         None => {
             println!("Clash v{}", env!("CARGO_PKG_VERSION"));
             println!("Try 'clash --help' for more information.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@ enum Commands {
 }
 
 fn main() {
-    // Force colors to always be enabled
+    // Force colors to always be enabled regardless of terminal capabilities
+    // TODO: Make color behavior configurable via --color flag (always/auto/never)
     control::set_override(true);
 
     let cli = Cli::parse();
@@ -64,23 +65,45 @@ fn main() {
                 std::process::exit(1);
             }
         },
-        Some(Commands::Check { path }) => match WorktreeManager::discover() {
-            Ok(worktrees) => match check::run_check(&worktrees, path.as_deref()) {
-                Ok(true) if path.is_some() => std::process::exit(2),
-                Ok(_) => {}
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    std::process::exit(1);
+        Some(Commands::Check { path }) => {
+            if let Some(ref p) = path {
+                // Manual mode: discover from cwd, exit 2 on conflicts
+                match WorktreeManager::discover() {
+                    Ok(worktrees) => match check::run_check(&worktrees, Some(p)) {
+                        Ok(true) => std::process::exit(2),
+                        Ok(false) => {}
+                        Err(e) => {
+                            eprintln!("Error: {}", e);
+                            std::process::exit(1);
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
+                    }
                 }
-            },
-            Err(e) => {
-                eprintln!("Error: {}", e);
-                std::process::exit(1);
+            } else {
+                // Hook mode: discover from file path in stdin
+                match check::run_check_from_hook() {
+                    Ok(_) => {}
+                    Err(e) => {
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
             }
-        },
+        }
         None => {
             println!("Clash v{}", env!("CARGO_PKG_VERSION"));
             println!("Try 'clash --help' for more information.");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn sanity_check() {
+        assert_eq!(1 + 1, 2);
     }
 }

--- a/src/watch/watcher.rs
+++ b/src/watch/watcher.rs
@@ -120,11 +120,14 @@ fn should_process_event(event: &notify::Event, gitignore: &Gitignore, repo_root:
         return false;
     }
 
-    // Filter for only actual content changes, not metadata
+    // Filter for actual content changes, not metadata.
+    // ModifyKind::Any is needed for macOS FSEvents which doesn't distinguish
+    // data vs metadata changes.
     matches!(
         event.kind,
-        EventKind::Modify(ModifyKind::Data(_)) |  // Actual content changes
+        EventKind::Modify(ModifyKind::Data(_)) |  // Content changes (Linux inotify)
         EventKind::Modify(ModifyKind::Name(_)) |  // Renames (git atomic operations)
+        EventKind::Modify(ModifyKind::Any) |       // Generic modify (macOS FSEvents)
         EventKind::Create(_) |                     // New files
         EventKind::Remove(_) // Deleted files
     )

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -20,12 +20,12 @@ impl WorktreeManager {
     }
 
     /// Discover all worktrees in the repository at the given path
-    fn discover_from(path: &str) -> Result<Self> {
+    pub fn discover_from(path: &str) -> Result<Self> {
         let path_buf = PathBuf::from(path);
         // Canonicalize path for better error messages
         let canonical_path = path_buf.canonicalize().unwrap_or_else(|_| path_buf.clone());
 
-        let repo = gix::open(path).map_err(|_| WorktreeError::NotARepository {
+        let repo = gix::discover(path).map_err(|_| WorktreeError::NotARepository {
             path: canonical_path.clone(),
         })?;
 

--- a/src/worktree/manager.rs
+++ b/src/worktree/manager.rs
@@ -35,11 +35,12 @@ impl WorktreeManager {
                 .join(&input)
         };
 
-        // gix::discover expects a directory; if given a file, use its parent
-        let discover_path = if abs_path.is_file() {
-            abs_path.parent().unwrap_or(&abs_path).to_path_buf()
-        } else {
+        // gix::discover expects a directory; if the path isn't a directory
+        // (file or non-existent path for new files), use its parent
+        let discover_path = if abs_path.is_dir() {
             abs_path.clone()
+        } else {
+            abs_path.parent().unwrap_or(&abs_path).to_path_buf()
         };
 
         let repo = gix::discover(&discover_path).map_err(|_| WorktreeError::NotARepository {


### PR DESCRIPTION
## Summary

- **Claude Code plugin**: New `claude-code-plugin/` directory with plugin manifest and PreToolUse hook that runs `clash check` on Write/Edit/MultiEdit operations — users get automatic conflict detection with a single `--plugin-dir` flag instead of manual settings.json configuration
- **Worktree discovery from file path**: `WorktreeManager::discover_from()` now accepts any path (file, directory, relative, absolute) and uses `gix::discover` to walk up and find the repository, so `clash check` works from any working directory
- **Fixed main worktree detection**: Uses `repo.common_dir()` instead of `repo.workdir()` to correctly identify the main worktree when discovered from a linked worktree
- **Fixed macOS watch mode**: Added `ModifyKind::Any` to the filesystem event filter since macOS FSEvents doesn't distinguish data vs metadata modifications
- **Marketplace manifest**: Added `marketplace.json` for self-hosted plugin distribution

## Test plan

- [x] `clash status` from main worktree, linked worktrees, subdirectories, parent directory, /tmp
- [x] `clash check <path>` with relative/absolute paths from all locations
- [x] Hook mode (stdin JSON) from all locations including new/non-existent files
- [x] Edge cases: invalid JSON, missing fields, empty stdin, non-repo paths
- [x] Watch mode auto-refresh on file edits (macOS)
- [x] Plugin validation with `claude plugin validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)